### PR TITLE
Fix #21012 - make it php7 compatible

### DIFF
--- a/QuickForm.php
+++ b/QuickForm.php
@@ -594,7 +594,7 @@ class HTML_QuickForm extends HTML_Common
         $className = $GLOBALS['HTML_QUICKFORM_ELEMENT_TYPES'][$type][1];
         $includeFile = $GLOBALS['HTML_QUICKFORM_ELEMENT_TYPES'][$type][0];
         include_once($includeFile);
-        $elementObject =& new $className();
+        $elementObject =new $className();
         for ($i = 0; $i < 5; $i++) {
             if (!isset($args[$i])) {
                 $args[$i] = null;
@@ -1704,7 +1704,7 @@ class HTML_QuickForm extends HTML_Common
     {
         if (!isset($GLOBALS['_HTML_QuickForm_default_renderer'])) {
             include_once('HTML/QuickForm/Renderer/Default.php');
-            $GLOBALS['_HTML_QuickForm_default_renderer'] =& new HTML_QuickForm_Renderer_Default();
+            $GLOBALS['_HTML_QuickForm_default_renderer'] =new HTML_QuickForm_Renderer_Default();
         }
         return $GLOBALS['_HTML_QuickForm_default_renderer'];
     } // end func defaultRenderer
@@ -1861,7 +1861,7 @@ class HTML_QuickForm extends HTML_Common
     function toArray($collectHidden = false)
     {
         include_once 'HTML/QuickForm/Renderer/Array.php';
-        $renderer =& new HTML_QuickForm_Renderer_Array($collectHidden);
+        $renderer =new HTML_QuickForm_Renderer_Array($collectHidden);
         $this->accept($renderer);
         return $renderer->toArray();
      } // end func toArray

--- a/QuickForm/Renderer/ObjectFlexy.php
+++ b/QuickForm/Renderer/ObjectFlexy.php
@@ -34,9 +34,9 @@ require_once 'HTML/QuickForm/Renderer/Object.php';
  *
  * Usage:
  * <code>
- * $form =& new HTML_QuickForm('form', 'POST');
- * $template =& new HTML_Template_Flexy();
- * $renderer =& new HTML_QuickForm_Renderer_ObjectFlexy(&$template);
+ * $form =new HTML_QuickForm('form', 'POST');
+ * $template =new HTML_Template_Flexy();
+ * $renderer =new HTML_QuickForm_Renderer_ObjectFlexy(&$template);
  * $renderer->setHtmlTemplate("html.html");
  * $renderer->setLabelTemplate("label.html");
  * $form->accept($renderer);

--- a/QuickForm/RuleRegistry.php
+++ b/QuickForm/RuleRegistry.php
@@ -125,7 +125,7 @@ class HTML_QuickForm_RuleRegistry
             if (!empty($path)) {
                 include_once($path);
             }
-            $this->_rules[$class] =& new $class();
+            $this->_rules[$class] =new $class();
         }
         $this->_rules[$class]->setName($ruleName);
         return $this->_rules[$class];

--- a/QuickForm/date.php
+++ b/QuickForm/date.php
@@ -423,7 +423,7 @@ class HTML_QuickForm_date extends HTML_QuickForm_group
                             $options = array($this->_options['emptyOptionValue'] => $this->_options['emptyOptionText']) + $options;
                         }
                     }
-                    $this->_elements[] =& new HTML_QuickForm_select($sign, null, $options, $this->getAttributes());
+                    $this->_elements[] =new HTML_QuickForm_select($sign, null, $options, $this->getAttributes());
                 }
             }
         }
@@ -511,7 +511,7 @@ class HTML_QuickForm_date extends HTML_QuickForm_group
     function toHtml()
     {
         include_once('HTML/QuickForm/Renderer/Default.php');
-        $renderer =& new HTML_QuickForm_Renderer_Default();
+        $renderer =new HTML_QuickForm_Renderer_Default();
         $renderer->setElementTemplate('{element}');
         parent::accept($renderer);
         return $this->_wrap[0] . $renderer->toHtml() . $this->_wrap[1];

--- a/QuickForm/group.php
+++ b/QuickForm/group.php
@@ -299,7 +299,7 @@ class HTML_QuickForm_group extends HTML_QuickForm_element
     function toHtml()
     {
         include_once('HTML/QuickForm/Renderer/Default.php');
-        $renderer =& new HTML_QuickForm_Renderer_Default();
+        $renderer =new HTML_QuickForm_Renderer_Default();
         $renderer->setElementTemplate('{element}');
         $this->accept($renderer);
         return $renderer->toHtml();

--- a/QuickForm/hierselect.php
+++ b/QuickForm/hierselect.php
@@ -164,7 +164,7 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
             // check if all elements have been created
             $totalNbElements = count($this->_options);
             for ($i = $this->_nbElements; $i < $totalNbElements; $i ++) {
-                $this->_elements[] =& new HTML_QuickForm_select($i, null, array(), $this->getAttributes());
+                $this->_elements[] =new HTML_QuickForm_select($i, null, array(), $this->getAttributes());
                 $this->_nbElements++;
             }
         }
@@ -219,7 +219,7 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
             // check if all elements have been created
             $totalNbElements = 2;
             for ($i = $this->_nbElements; $i < $totalNbElements; $i ++) {
-                $this->_elements[] =& new HTML_QuickForm_select($i, null, array(), $this->getAttributes());
+                $this->_elements[] =new HTML_QuickForm_select($i, null, array(), $this->getAttributes());
                 $this->_nbElements++;
             }
         }
@@ -286,7 +286,7 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
     function _createElements()
     {
         for ($i = 0; $i < $this->_nbElements; $i++) {
-            $this->_elements[] =& new HTML_QuickForm_select($i, null, array(), $this->getAttributes());
+            $this->_elements[] =new HTML_QuickForm_select($i, null, array(), $this->getAttributes());
         }
     } // end func _createElements
 
@@ -464,7 +464,7 @@ JAVASCRIPT;
                           $this->_convertArrayToJavascript($values) . ";\n";
         }
         include_once('HTML/QuickForm/Renderer/Default.php');
-        $renderer =& new HTML_QuickForm_Renderer_Default();
+        $renderer =new HTML_QuickForm_Renderer_Default();
         $renderer->setElementTemplate('{element}');
         parent::accept($renderer);
 

--- a/docs/elements.php
+++ b/docs/elements.php
@@ -13,7 +13,7 @@
 
 require_once 'HTML/QuickForm.php';
 
-$form =& new HTML_QuickForm('frmTest', 'get');
+$form =new HTML_QuickForm('frmTest', 'get');
 
 // Use a two-label template for the elements that require some comments
 $twoLabel = <<<_HTML

--- a/docs/filters.php
+++ b/docs/filters.php
@@ -18,7 +18,7 @@ function _filterAustin($value)
     return strtoupper($value).', GROOVY BABY!';
 }
 
-$form =& new HTML_QuickForm('frmTest', 'get');
+$form =new HTML_QuickForm('frmTest', 'get');
 
 $form->addElement('text', 'txtTest', 'Test Text to trim:');
 $form->addRule('txtTest', 'Test text is required', 'required');

--- a/docs/formrule.php
+++ b/docs/formrule.php
@@ -59,7 +59,7 @@ function _validate_shipping($values)
     return empty($errors)? true: $errors;
 }
 
-$form =& new HTML_QuickForm('frmFancy');
+$form =new HTML_QuickForm('frmFancy');
 $form->setDefaults(array(
     'profile'     => 'existing',
     'stuffAmount' => '1'

--- a/docs/groups.php
+++ b/docs/groups.php
@@ -12,7 +12,7 @@
 
 require_once 'HTML/QuickForm.php';
 
-$form =& new HTML_QuickForm('frmGroups');
+$form =new HTML_QuickForm('frmGroups');
 $form->setDefaults(array(
     'id'        => array('lastname' => 'Mamasam', 'code' => '1234'),
     'phoneNo'   => array('513', '123', '3456'),

--- a/docs/renderers/FlexyDynamic_example.php
+++ b/docs/renderers/FlexyDynamic_example.php
@@ -72,7 +72,7 @@ if ($form->validate()) {
     $form->freeze();
 }
 
-$renderer =& new HTML_QuickForm_Renderer_Object(true);
+$renderer =new HTML_QuickForm_Renderer_Object(true);
 
 // give some elements aditional style informations
 $renderer->setElementStyle(array(
@@ -90,7 +90,7 @@ $options = array(
 	'compileDir' => './templates/build',
 	'debug' => 0
 );
-$tpl =& new HTML_Template_Flexy($options);
+$tpl =new HTML_Template_Flexy($options);
 
 //$tpl->compile("styles/green.html");
 //$tpl->compile("styles/fancygroup.html");

--- a/docs/renderers/FlexyStatic_example.php
+++ b/docs/renderers/FlexyStatic_example.php
@@ -129,7 +129,7 @@ $options = array(
 
 $template = new HTML_Template_Flexy($options);
 
-$renderer =& new HTML_QuickForm_Renderer_ObjectFlexy($template);
+$renderer =new HTML_QuickForm_Renderer_ObjectFlexy($template);
 $renderer->setLabelTemplate("label.html");
 $renderer->setHtmlTemplate("html.html");
 

--- a/docs/renderers/ITDynamic_example.php
+++ b/docs/renderers/ITDynamic_example.php
@@ -75,13 +75,13 @@ if ($form->validate()) {
 
 // create a template object and load the template file
 // can use either HTML_Template_Sigma or HTML_Template_ITX
-$tpl =& new HTML_Template_ITX('./templates');
-// $tpl =& new HTML_Template_Sigma('./templates');
+$tpl =new HTML_Template_ITX('./templates');
+// $tpl =new HTML_Template_Sigma('./templates');
 
 $tpl->loadTemplateFile('it-dynamic.html', true, true);
 
 // create a renderer
-$renderer =& new HTML_QuickForm_Renderer_ITDynamic($tpl);
+$renderer =new HTML_QuickForm_Renderer_ITDynamic($tpl);
 
 // assign elements to blocks
 $renderer->setElementBlock(array(

--- a/docs/renderers/ITDynamic_example2.php
+++ b/docs/renderers/ITDynamic_example2.php
@@ -105,12 +105,12 @@ if ($form->validate()) {
 
 
 // can use either HTML_Template_Sigma or HTML_Template_ITX
-$tpl =& new HTML_Template_ITX('./templates');
-// $tpl =& new HTML_Template_Sigma('./templates');
+$tpl =new HTML_Template_ITX('./templates');
+// $tpl =new HTML_Template_Sigma('./templates');
 
 $tpl->loadTemplateFile('it-dynamic-2.html');
 
-$renderer =& new HTML_QuickForm_Renderer_ITDynamic($tpl);
+$renderer =new HTML_QuickForm_Renderer_ITDynamic($tpl);
 $renderer->setElementBlock(array(
     'name'     => 'qf_group_table',
     'address'  => 'qf_group_table'

--- a/docs/renderers/ITStatic_example.php
+++ b/docs/renderers/ITStatic_example.php
@@ -100,10 +100,10 @@ if ($form->validate()) {
 }
 
 // Could be HTML_Template_Sigma('./templates')
-$tpl =& new HTML_Template_ITX('./templates');
+$tpl =new HTML_Template_ITX('./templates');
 $tpl->loadTemplateFile('it-static.html');
 
-$renderer =& new HTML_QuickForm_Renderer_ITStatic($tpl);
+$renderer =new HTML_QuickForm_Renderer_ITStatic($tpl);
 $renderer->setRequiredTemplate('{label}<font color="red" size="1">*</font>');
 $renderer->setErrorTemplate('<font color="orange" size="1">{error}</font><br />{html}');
 

--- a/docs/renderers/QuickHtml_example.php
+++ b/docs/renderers/QuickHtml_example.php
@@ -21,9 +21,9 @@
 
 require_once ("HTML/QuickForm.php");
 require_once ("HTML/QuickForm/Renderer/QuickHtml.php");
-$form =& new HTML_QuickForm('tmp_form','POST');
+$form =new HTML_QuickForm('tmp_form','POST');
 // get our render
-$renderer =& new HTML_QuickForm_Renderer_QuickHtml();
+$renderer =new HTML_QuickForm_Renderer_QuickHtml();
 // create the elements
 createElements($form);
 // set their values

--- a/docs/renderers/SmartyDynamic_example.php
+++ b/docs/renderers/SmartyDynamic_example.php
@@ -78,7 +78,7 @@ if ($form->validate()) {
     $form->freeze();
 }
 
-$renderer =& new HTML_QuickForm_Renderer_Array(true, true);
+$renderer =new HTML_QuickForm_Renderer_Array(true, true);
 
 // give some elements aditional style informations
 $renderer->setElementStyle(array(
@@ -90,7 +90,7 @@ $renderer->setElementStyle(array(
 $form->accept($renderer);
 
 // setup a template object
-$tpl =& new Smarty;
+$tpl =new Smarty;
 $tpl->template_dir = './templates';
 $tpl->compile_dir  = './templates';
 

--- a/docs/renderers/SmartyStatic_example.php
+++ b/docs/renderers/SmartyStatic_example.php
@@ -99,11 +99,11 @@ if ($form->validate()) {
 }
 
 // setup a template object
-$tpl =& new Smarty;
+$tpl =new Smarty;
 $tpl->template_dir = './templates';
 $tpl->compile_dir  = './templates';
 
-$renderer =& new HTML_QuickForm_Renderer_ArraySmarty($tpl, true);
+$renderer =new HTML_QuickForm_Renderer_ArraySmarty($tpl, true);
 
 $renderer->setRequiredTemplate(
    '{if $error}

--- a/docs/rules-builtin.php
+++ b/docs/rules-builtin.php
@@ -11,7 +11,7 @@
 
 require_once 'HTML/QuickForm.php';
 
-$form =& new HTML_QuickForm('builtin');
+$form =new HTML_QuickForm('builtin');
 
 // We need an additional label below the element
 $renderer =& $form->defaultRenderer();

--- a/docs/rules-custom.php
+++ b/docs/rules-custom.php
@@ -71,7 +71,7 @@ function countUpper_old($name, $value, $limit = null)
     return (count($upper) / strlen($value)) <= $limit;
 }
 
-$form =& new HTML_QuickForm('custom');
+$form =new HTML_QuickForm('custom');
 
 $form->addElement('header', null, 'Custom rule class');
 

--- a/package2.xml
+++ b/package2.xml
@@ -252,7 +252,7 @@ Features:
  <dependencies>
   <required>
    <php>
-    <min>4.3</min>
+    <min>5.4</min>
    </php>
    <pearinstaller>
     <min>1.5.4</min>


### PR DESCRIPTION
This fixes Pear bug #21012 and will enable QuickForm to be used on php7.

Maybe this will make the code behave different when run on php4, since it did assign objects by value. But the code can still be run on php 4.3 (according to php-compatinfo)
